### PR TITLE
fix(discord): icon path + node-fetch dependency

### DIFF
--- a/discord/createPostOnDiscordChannel.ts
+++ b/discord/createPostOnDiscordChannel.ts
@@ -6,7 +6,7 @@ import dotenv from 'dotenv'
 dotenv.config()
 
 //Load OpenSea icon
-const file = new AttachmentBuilder('./icon/se.ico');
+const file = new AttachmentBuilder(`${__dirname}/icon/se.ico`);
 
 
 // Send message on discord

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "dependencies": {
     "discord.js": "^14.11.0",
     "dotenv": "^16.0.3",
+    "node-fetch": "2.6.7",
     "typescript": "^5.0.4"
   },
   "devDependencies": {


### PR DESCRIPTION
Fixed errors when launching tool for the first time. 
- icon path
- node-fetch dependency