### PR TITLE
feat(stream): posts new releases of a github repo

### DIFF
--- a/discord/createEmbed.ts
+++ b/discord/createEmbed.ts
@@ -1,28 +1,55 @@
-import {EmbedBuilder} from 'discord.js'
+import { EmbedBuilder } from 'discord.js'
 import { Question } from '../types';
+import { Release } from '../github/types';
 
 
 export const createEmbedQuestion = (data: Question) => {
-    // Create embed
-    const embed = new EmbedBuilder()
-      .setColor(0xcc0000)
-      .setTitle(data.title)
-      .setURL(`${data.link}`)
-      .setAuthor({
-        name: `Question from ${data.owner.display_name}`,
-        iconURL: data.owner.profile_image
-      })
-      .addFields(
-        {
-          name: 'Tags',
-          value: `${data.tags}`,
-        },
-      )
-      .setTimestamp(data.creation_date)
-      .setFooter({
-        text: `Powered by WBA`,
-        iconURL: 'attachment://se.ico',
-      })
-      
-    return embed  
-  };
+  // Create embed
+  const embed = new EmbedBuilder()
+    .setColor(0xcc0000)
+    .setTitle(data.title)
+    .setURL(`${data.link}`)
+    .setAuthor({
+      name: `Question from ${data.owner.display_name}`,
+      iconURL: data.owner.profile_image
+    })
+    .addFields(
+      {
+        name: 'Tags',
+        value: `${data.tags}`,
+      },
+    )
+    .setTimestamp(data.creation_date)
+    .setFooter({
+      text: `Powered by WBA`,
+      iconURL: 'attachment://se.ico',
+    })
+
+  return embed
+};
+
+export const createEmbedRelease = (data: Release) => {
+  // Create embed
+  const embed = new EmbedBuilder()
+    .setColor(0xcc0000)
+    .setTitle(data.name)
+    .setURL(`${data.url}`)
+    .setAuthor({
+      name: `Release for ${data.repo} by ${data.author.login}`,
+      iconURL: data.author.avatar_url,
+    })
+    .setDescription(data.body)
+    .addFields(
+      {
+        name: 'Tags',
+        value: `${data.tag_name}`,
+      },
+    )
+    .setTimestamp(new Date(data.published_at))
+    .setFooter({
+      text: `Powered by WBA`,
+      iconURL: 'attachment://se.ico',
+    })
+
+  return embed
+};

--- a/discord/createPostOnDiscordChannel.ts
+++ b/discord/createPostOnDiscordChannel.ts
@@ -1,35 +1,56 @@
-import {Client,  ChannelType, AttachmentBuilder} from 'discord.js'
-import { createEmbedQuestion } from './createEmbed';
+import { Client, ChannelType, AttachmentBuilder, EmbedBuilder } from 'discord.js'
+import { createEmbedQuestion, createEmbedRelease } from './createEmbed';
 import { Question } from '../types';
 import dotenv from 'dotenv'
+import { Release } from '../github/types';
 
 dotenv.config()
 
 //Load OpenSea icon
 const file = new AttachmentBuilder(`${__dirname}/icon/se.ico`);
 
+type EmbedInfo = {
+    question?: Question,
+    release?: Release,
+}
 
 // Send message on discord
 export const createPostOnDiscordChannel = async (
-    client: Client, 
-    embedInfo: Question) => {
-        try {
-            // Check if client is ready
-            if (!client.isReady()) {
-                console.log('Discord client is not ready')
-                return
-            }
-            const channelId: any = process.env.DISCORD_CHANNEL_ID
-            const questionLink = embedInfo.link
-            const channel = await client.channels.fetch(channelId)
-            const embed = createEmbedQuestion(embedInfo)
-            // Check if channel is a text channel
-            if(channel?.type === ChannelType.GuildText){
-                channel.send(questionLink);
-                channel.send({ embeds: [embed], files: [file]});
-            }    
-            console.log('Posted on Discord successfully')
-        } catch (error) {
-        console.error('Post on discord channel failed ', error)
+    client: Client,
+    channelId: string,
+    embedInfo: EmbedInfo,
+) => {
+    try {
+        // Check if client is ready
+        if (!client.isReady()) {
+            console.log('Discord client is not ready')
+            return
         }
+        
+        let embed: EmbedBuilder | undefined;
+        let link: string | undefined;
+        
+        if (embedInfo.question) {
+            link = embedInfo.question.link;
+            embed = createEmbedQuestion(embedInfo.question);
+        } else if (embedInfo.release) {
+            link = embedInfo.release.url;
+            embed = createEmbedRelease(embedInfo.release);
+        }
+        
+        if (!embed || !link) {
+            throw new Error('No embed post or link found.')
+        }
+        
+        const channel = await client.channels.fetch(channelId);
+
+        // Check if channel is a text channel
+        if (channel?.type === ChannelType.GuildText) {
+            channel.send(link);
+            channel.send({ embeds: [embed], files: [file] });
+        }
+        console.log('Posted on Discord successfully')
+    } catch (error) {
+        console.error('Post on discord channel failed ', error)
+    }
 }

--- a/github/api.ts
+++ b/github/api.ts
@@ -1,0 +1,34 @@
+import fetch from 'node-fetch';
+import { Release, RepoInfo } from './types';
+
+const githubApi = {
+    getReleases: async (repoInfo: RepoInfo): Promise<Release[]> => {
+        try {
+            let newReleases = [];
+            const lastReleaseDate = repoInfo.lastReleaseDate;
+            const releases = await fetch(`https://api.github.com/repos/${repoInfo.owner}/${repoInfo.repo}/releases?per_page=3`)
+                .then(res => res.json());
+
+            if (releases?.length > 0) {
+                if (!lastReleaseDate) {
+                    //On first run it returns the last release. 
+                    newReleases = releases.slice(0, 1);
+                } else {
+                    //Then returns any new releases.
+                    newReleases = releases.filter((release: Release) => new Date(release.published_at) > new Date(lastReleaseDate));
+                }
+                newReleases = newReleases.map((release: Release) => ({ ...release, owner: repoInfo.owner, repo: repoInfo.repo }));
+            }
+
+            if (newReleases.length > 0) {
+                //Saves the publish date of the latest release.
+                repoInfo.lastReleaseDate = newReleases[0].published_at
+            }
+            return newReleases;
+        } catch (err) {
+            throw err;
+        }
+    }
+}
+
+export default githubApi;

--- a/github/config.ts
+++ b/github/config.ts
@@ -1,0 +1,9 @@
+import { RepoInfo } from "./types";
+
+export const repos: RepoInfo[] = [
+    {
+        owner: 'solana-labs',
+        repo: 'solana',
+        lastReleaseDate: undefined,
+    },
+]

--- a/github/types.ts
+++ b/github/types.ts
@@ -1,0 +1,19 @@
+export type RepoInfo = {
+    owner: string,
+    repo: string,
+    lastReleaseDate?: string,
+}
+
+export type Release = {
+    author: {
+        avatar_url: string,
+        login: string,
+    },
+    body: string,
+    name: string,
+    owner: string,
+    published_at: string,
+    repo: string,
+    tag_name: string,
+    url: string,
+}

--- a/module/feedApp.ts
+++ b/module/feedApp.ts
@@ -2,27 +2,41 @@ import { initDiscord } from "../discord/client";
 import { getQuestions } from "../stack-exchange-api/getQuestions";
 import { createPostOnDiscordChannel } from "../discord/createPostOnDiscordChannel";
 import { initTelegram } from "../telegram/client";
+import { repos } from "../github/config";
+import githubApi from "../github/api";
 
 (async () => {
-    try{
+    try {
         // Init discord client
         const client = await initDiscord();
+        const channelId = process.env.DISCORD_CHANNEL_ID as string;
 
         // Init telegram bot
         let bot = initTelegram()
 
-
+        const intervalSeconds = 300;
         setInterval(async () => {
             // Get questions from StackExchange API
-            const questions = await getQuestions(5, 'solana')
-            
-            // Post questions on Discord
+            const questions = await getQuestions(intervalSeconds, 'solana')
+
+            // Post questions on Discord and Telegram
             questions.forEach(async (question) => {
-                await createPostOnDiscordChannel(client, question)
+                await createPostOnDiscordChannel(client, channelId, { question })
                 bot?.sendMessage(process.env.TELEGRAM_CHAT_ID || '', question.link)
             })
-        }, 300000)
-    }catch(error){
+
+            for (let repo of repos) {
+                // Get releases of each repo from github API
+                const releases = await githubApi.getReleases(repo);
+
+                // Post each release on Discord and Telegram
+                for (let release of releases) {
+                    await createPostOnDiscordChannel(client, channelId, { release })
+                    bot?.sendMessage(process.env.TELEGRAM_CHAT_ID || '', release.url)
+                }
+            }
+        }, intervalSeconds * 1000);
+    } catch (error) {
         console.log(error)
     }
 })()

--- a/stack-exchange-api/getQuestions.ts
+++ b/stack-exchange-api/getQuestions.ts
@@ -1,10 +1,9 @@
 import fetch from 'node-fetch';
 import { QuestionResponse } from '../types';
 
-export const getQuestions = async (minutes : number, site: string) => {
+export const getQuestions = async (seconds : number, site: string) => {
 
     // Date X minutes ago
-    const seconds = minutes * 60
     const date = ((Math.floor((Date.now()/1000)/seconds))*seconds)-seconds
 
     // Call StackExchange API


### PR DESCRIPTION
**Fixes:** 
- set channelId as a prop to allow posting different streams to different channels
- set interval in seconds to better match with question delay requirement

**Feature:**
- fetched repo releases from github's basic api (no auth)
- saved published date on fetch to filter new releases
- created embed Discord post for releases